### PR TITLE
Using -f to only get state

### DIFF
--- a/scripts/get_actual_song.sh
+++ b/scripts/get_actual_song.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-string="$(spt playback)"
+string="$(spt playback -f '%s')"
 firstletter=${string:0:1}
 
 if [[ "$firstletter" == "▶" ]]; then


### PR DESCRIPTION
This prevents an issue when you're shuffling songs. By default `spt playback` seems to throw the shuffle indicator in front which makes the script think nothing is playing. 

![image](https://user-images.githubusercontent.com/71444041/201496691-d11d9a07-ad51-41a6-b26f-cb2a50616bc4.png)

Changing it to `spt playback -f '%s'` only prints the status fixes this.